### PR TITLE
'filter' object has no attribute 'append' in python3

### DIFF
--- a/lib/ansible/modules/system/capabilities.py
+++ b/lib/ansible/modules/system/capabilities.py
@@ -108,7 +108,7 @@ class CapabilitiesModule(object):
                 self.module.exit_json(changed=True, msg='capabilities changed')
             else:
                 # remove from current cap list if it's already set (but op/flags differ)
-                current = filter(lambda x: x[0] != self.capability_tup[0], current)
+                current = list(filter(lambda x: x[0] != self.capability_tup[0], current))
                 # add new cap with correct op/flags
                 current.append( self.capability_tup )
                 self.module.exit_json(changed=True, state=self.state, msg='capabilities changed', stdout=self.setcap(self.path, current))


### PR DESCRIPTION
Fixes issue when using python3 interpreter: 'filter' object has no attribute 'append'
Ensure list type of data is used before appending data.

##### SUMMARY
utilize list() to ensure list type of data is used prior to attempting to append capabilities. This was implicit in python 2.7 because filter() returned a list data type. In python3 filter() returns a filter type object.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/system/capabilities.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 3b5dd4e0a0) last updated 2017/04/11 00:33:25 (GMT +000)
  config file = 
  configured module search path = [u'/home/catatonic/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.9 (default, Sep 17 2016, 20:26:04) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
Inventory:
server1 ansible_connection=ssh ansible_user=ubuntu ansible_host=123.45.67.89 ansible_python_interpreter=/usr/bin/python3

servers.yml:
    ...
    - name: set network capability
      become: true
      capabilities:
        capability: cap_net_bind_service+ep
        path: "/bin/nc"
        state: present
    ...

$ ansible-playbook -i Inventory servers.yml --start-at-task="set network capability"

Resulting error:
```
fatal: [server1]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Shared connection to 123.45.67.89 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_gpvn7i49/ansible_module_capabilities.py\", line 199, in <module>\r\n    main()\r\n  File \"/tmp/ansible_gpvn7i49/ansible_module_capabilities.py\", line 192, in main\r\n    CapabilitiesModule(module)\r\n  File \"/tmp/ansible_gpvn7i49/ansible_module_capabilities.py\", line 98, in __init__\r\n    self.run()\r\n  File \"/tmp/ansible_gpvn7i49/ansible_module_capabilities.py\", line 113, in run\r\n    current.append( self.capability_tup )\r\nAttributeError: 'filter' object has no attribute 'append'\r\n", "msg": "MODULE FAILURE", "rc": 0}
```

After fix:
```
TASK [set network capability] ************************************************************************
changed: [server1]
```
